### PR TITLE
[PROTO-56] Add __version__ to PROTOplast package

### DIFF
--- a/src/protoplast/__init__.py
+++ b/src/protoplast/__init__.py
@@ -15,6 +15,19 @@
 
 """Top-level package for protoplast."""
 
+# Dynamically read version from pyproject.toml
+
+# Dynamically get version from installed package metadata
+try:
+	from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+	from importlib_metadata import version, PackageNotFoundError  # type: ignore
+
+try:
+	__version__ = version("protoplast")
+except PackageNotFoundError:
+	__version__ = "unknown"
+
 from protoplast.scrna.anndata.lightning_models import LinearClassifier
 from protoplast.scrna.anndata.torch_dataloader import DistributedAnnDataset, DistributedCellLineAnnDataset
 from protoplast.scrna.anndata.trainer import RayTrainRunner


### PR DESCRIPTION
[JIRA Ticket](https://dataxight.atlassian.net/browse/PROTO-56?actionerId=712020%3A9277520e-545e-45da-b6a4-6486a3ef4304&sourceType=assign)

String `__version__` is evaluated from importlib runtime to make sure its consistency with the version seen from pip list.

## Test Evidence
pip install . 
Then, import protoplast and print __version__.
The output is 0.1.1 as shown below. Note: session_info now shows the correct version of protoplast. So, it most likely gets `__version__` string for display if available.

<img width="823" height="108" alt="Screenshot 2568-10-06 at 16 49 36" src="https://github.com/user-attachments/assets/e0f90225-462e-4329-bd13-e5bc9f513d2f" />
