### PR TITLE
[PROTO-54] make the logging more clear if GPU is activated

### DIFF
--- a/src/protoplast/scrna/anndata/trainer.py
+++ b/src/protoplast/scrna/anndata/trainer.py
@@ -189,14 +189,14 @@ class RayTrainRunner:
             scaling_config = ray.train.ScalingConfig(
                 num_workers=num_workers, use_gpu=True, resources_per_worker=resource_per_worker
             )
-            resource_per_worker["GPU"] = num_workers
+            resource_per_worker["GPU"] = 1
         else:
             if num_workers is None:
                 num_workers = max(int((self.resources.get("CPU", 2) - 1) / thread_per_worker), 1)
             scaling_config = ray.train.ScalingConfig(
                 num_workers=num_workers, use_gpu=False, resources_per_worker=resource_per_worker
             )
-        print(f"Using {num_workers} workers with {resource_per_worker}")
+        print(f"Using {num_workers} workers where each worker uses: {resource_per_worker}")
         start = time.time()
         shuffle_strategy = self.shuffle_strategy(
             file_paths,


### PR DESCRIPTION
Print out how many GPU is using if activated make it very clear to the user because we know that PROTOplast use the amount of GPU equal to the amount of worker.