### PR TITLE
[PROTO-71] Fallback to cpu for mac

### DIFF
--- a/src/protoplast/scrna/anndata/trainer.py
+++ b/src/protoplast/scrna/anndata/trainer.py
@@ -17,9 +17,9 @@ import logging
 import os
 import time
 import uuid
+import warnings
 from collections.abc import Callable
 from typing import Literal
-import warnings
 
 import anndata
 import lightning.pytorch as pl
@@ -317,7 +317,7 @@ def _get_accelerator() -> Literal["cpu", "auto"]:
     if torch.backends.mps.is_available():
         # TODO: Make RayDDPStrategy compatible with MPS
         accelerator = "cpu"
-        warnings.warn("RayTrainRunner does not support MPS accelarator yet. Fallback to CPU", UserWarning)
+        warnings.warn("RayTrainRunner does not support MPS accelarator yet. Fallback to CPU", UserWarning, stacklevel=2)
     else:
         accelerator = "auto"
     return accelerator


### PR DESCRIPTION
## Changes

* Fallback to cpu for mac

## How this PR was tested?

The follow cmd could run on a mac device:

```bash
uv run pytest tests/test_trainer.py
```