### PR TITLE
[PROTO-88] Remove `working_dir` option

### DIFF
--- a/src/protoplast/scrna/anndata/trainer.py
+++ b/src/protoplast/scrna/anndata/trainer.py
@@ -112,7 +112,6 @@ class RayTrainRunner:
 
         # Init ray cluster
         DEFAULT_RUNTIME_ENV_CONFIG = {
-            "working_dir": os.getenv("PWD"),  # Allow ray workers to inherit venv at $PWD if there is any
             "LOG_LEVEL": os.getenv("LOG_LEVEL", "INFO"),
         }
         if runtime_env_config is None:


### PR DESCRIPTION
* `PWD` can be on system path or kernel path the notebook or library is not suppose to access
* The user can manually inject `working_dir` by themselves if they know what they are doing no need to set it for normal single cluster usage
* `protoray` automatically handle this for the user of injecting the correct `working_dir`